### PR TITLE
"class" is a reserved word in node 0.6

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -380,24 +380,24 @@ AbstractClass.scope = function (name, params) {
     defineScope(this, this, name, params);
 };
 
-function defineScope(class, targetClass, name, params, methods) {
+function defineScope(cls, targetClass, name, params, methods) {
 
     // collect meta info about scope
-    if (!class._scopeMeta) {
-        class._scopeMeta = {};
+    if (!cls._scopeMeta) {
+        cls._scopeMeta = {};
     }
 
     // anly make sence to add scope in meta if base and target classes
     // are same
-    if (class === targetClass) {
-        class._scopeMeta[name] = params;
+    if (cls === targetClass) {
+        cls._scopeMeta[name] = params;
     } else {
         if (!targetClass._scopeMeta) {
             targetClass._scopeMeta = {};
         }
     }
 
-    Object.defineProperty(class, name, {
+    Object.defineProperty(cls, name, {
         enumerable: false,
         configurable: true,
         get: function () {

--- a/lib/adapters/neo4j.js
+++ b/lib/adapters/neo4j.js
@@ -21,15 +21,15 @@ Neo4j.prototype.define = function defineModel(descr) {
     this._models[descr.model.modelName] = descr;
 };
 
-Neo4j.prototype.createIndexHelper = function (class, indexName) {
+Neo4j.prototype.createIndexHelper = function (cls, indexName) {
     var db = this.client;
     var method = 'findBy' + indexName[0].toUpperCase() + indexName.substr(1);
-    class[method] = function (value, cb) {
-        db.getIndexedNode(class.modelName, indexName, value, function (err, node) {
+    cls[method] = function (value, cb) {
+        db.getIndexedNode(cls.modelName, indexName, value, function (err, node) {
             if (err) return cb(err);
             if (node) {
                 node.data.id = node.id;
-                cb(null, new class(node.data));
+                cb(null, new cls(node.data));
             } else {
                 cb(null, null);
             }
@@ -37,17 +37,17 @@ Neo4j.prototype.createIndexHelper = function (class, indexName) {
     };
 };
 
-Neo4j.prototype.mixClassMethods = function mixClassMethods(class, properties) {
+Neo4j.prototype.mixClassMethods = function mixClassMethods(cls, properties) {
     var neo = this;
 
     Object.keys(properties).forEach(function (name) {
         if (properties[name].index) {
-            neo.createIndexHelper(class, name);
+            neo.createIndexHelper(cls, name);
         }
     });
 
-    class.setupCypherQuery = function (name, queryStr, rowHandler) {
-        class[name] = function cypherQuery(params, cb) {
+    cls.setupCypherQuery = function (name, queryStr, rowHandler) {
+        cls[name] = function cypherQuery(params, cb) {
             if (typeof params === 'function') {
                 cb = params;
                 params = [];
@@ -74,7 +74,7 @@ Neo4j.prototype.mixClassMethods = function mixClassMethods(class, properties) {
      * @param direction - all | incoming | outgoing
      * @param cb - callback (err, rel || false)
      */
-    class.relationshipExists = function relationshipExists(from, to, type, direction, cb) {
+    cls.relationshipExists = function relationshipExists(from, to, type, direction, cb) {
         neo.node(from, function (err, node) {
             if (err) return cb(err);
             node._getRelationships(direction, type, function (err, rels) {
@@ -93,7 +93,7 @@ Neo4j.prototype.mixClassMethods = function mixClassMethods(class, properties) {
         });
     };
 
-    class.createRelationshipTo = function createRelationshipTo(id1, id2, type, data, cb) {
+    cls.createRelationshipTo = function createRelationshipTo(id1, id2, type, data, cb) {
         var fromNode, toNode;
         neo.node(id1, function (err, node) {
             if (err && cb) return cb(err);
@@ -114,17 +114,17 @@ Neo4j.prototype.mixClassMethods = function mixClassMethods(class, properties) {
         }
     };
 
-    class.createRelationshipFrom = function createRelationshipFrom(id1, id2, type, data, cb) {
-        class.createRelationshipTo(id2, id1, type, data, cb);
+    cls.createRelationshipFrom = function createRelationshipFrom(id1, id2, type, data, cb) {
+        cls.createRelationshipTo(id2, id1, type, data, cb);
     }
 
     // only create relationship if it is not exists
-    class.ensureRelationshipTo = function (id1, id2, type, data, cb) {
-        class.relationshipExists(id1, id2, type, 'outgoing', function (err, exists) {
+    cls.ensureRelationshipTo = function (id1, id2, type, data, cb) {
+        cls.relationshipExists(id1, id2, type, 'outgoing', function (err, exists) {
             if (err && cb) return cb(err);
             if (err && !cb) throw err;
             if (exists) return cb && cb(null);
-            class.createRelationshipTo(id1, id2, type, data, cb);
+            cls.createRelationshipTo(id1, id2, type, data, cb);
         });
     }
 };

--- a/lib/validatable.js
+++ b/lib/validatable.js
@@ -207,9 +207,9 @@ function blank(v) {
     return false;
 }
 
-function configure(class, validation, args) {
-    if (!class._validations) {
-        Object.defineProperty(class, '_validations', {
+function configure(cls, validation, args) {
+    if (!cls._validations) {
+        Object.defineProperty(cls, '_validations', {
             writable: true,
             configurable: true,
             enumerable: false,
@@ -225,7 +225,7 @@ function configure(class, validation, args) {
     }
     conf.validation = validation;
     args.forEach(function (attr) {
-        class._validations.push([attr, conf]);
+        cls._validations.push([attr, conf]);
     });
 }
 


### PR DESCRIPTION
Hello,

In several places in the code, there is a "class" used as a variable's name. Since "class" is a reserved word in V8 and Node 0.6, it emits errors like these:

``` javascript
function defineScope(class, targetClass, name, params, methods) {
                     ^^^^^

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
SyntaxError: <unknown message reserved_word>
```

I replaced occurrences of  "class" with "cls". If I missed some, notify me :)

Regards,
Justinas
