### PR TITLE
Updates to the mysql adapter

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -66,17 +66,7 @@ MySQL.prototype.toFields = function (model, data) {
     var props = this._models[model].properties;
     Object.keys(data).forEach(function (key) {
         if (props[key]) {
-        	if(key.indexOf('.') != -1) {
-        		keys = key.split('.');
-        		
-        		for(var item = 0; item < keys.length; item++) {
-        			keys[item] = '`' + keys[item] + '`';
-        		}
-        		
-        		key = keys.join('.');
-        	}
-        	
-            fields.push('`' + key + '` = ' + this.toDatabase(props[key], data[key]));
+        	fields.push('`' + key.replace(/\./g, '`.`') + '` = ' + this.toDatabase(props[key], data[key]));
         }
     }.bind(this));
     return fields.join(',');


### PR DESCRIPTION
Updated mysql adapter to support fields that have internal names like
"key" or "order"(they will be escaped to "`key`" and "`order`"), also
added support in case of query generates fields like "table.field" that
will be escaped to "`table`.`field`"
