### PR TITLE
Async validations should not trump previous validations

### DIFF
--- a/lib/validatable.js
+++ b/lib/validatable.js
@@ -133,7 +133,7 @@ Validatable.prototype.isValid = function (callback) {
             asyncFail = asyncFail || fail;
             if (--wait === 0 && callback) {
                 validationsDone.call(inst, function () {
-                    callback(!asyncFail);
+                    callback(valid && !asyncFail);
                 });
             }
         }


### PR DESCRIPTION
Previous validations should be true as well as async validations
