### PR TITLE
Safety: there might not be any indexes to use

### DIFF
--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -159,7 +159,7 @@ BridgeToRedis.prototype.all = function all(model, filter, callback) {
         var indexes = pi[0];
         var noIndexes = pi[1];
 
-        if (indexes.length) {
+        if (indexes && indexes.length) {
             cmd = 'SINTER "' + indexes.join('" "') + '"';
             if (noIndexes.length) {
                 log(model + ': no indexes found for ', noIndexes.join(', '),


### PR DESCRIPTION
Prior to this, calling `someModel.all({ where: {} }, callback)` would cause:

```
TypeError: Cannot read property 'length' of undefined
    at BridgeToRedis.all (/home/bergie/Projects/resource-juggling/node_modules/jugglingdb/lib/adapters/redis.js:162:20)
    at Function.all (/home/bergie/Projects/resource-juggling/node_modules/jugglingdb/lib/abstract-class.js:201:25)
    at /home/bergie/Projects/resource-juggling/lib/resource-juggling.coffee:52:28
```

This seems to be a regression in 0.1.0, as earlier JugglingDB just worked here.
