### PR TITLE
Fix unconstrained all on MySQL

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -241,6 +241,9 @@ MySQL.prototype.all = function all(model, filter, callback) {
                 cs.push(keyEscaped + ' = ' + val);
             }
         });
+        if (cs.length === 0) {
+          return '';
+        }
         return 'WHERE ' + cs.join(' AND ');
     }
 


### PR DESCRIPTION
Without this patch, an unconstrained `all` on JugglingDB using the MySQL adapter would generate queries like:

```
SELECT * FROM Track WHERE  
```

Now it is more correctly:

```
SELECT * FROM Track 
```
