### PR TITLE
Pass DEFAULT on columns configured with autoincrement

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -109,7 +109,16 @@ function dateToPostgres(val) {
 }
 
 PG.prototype.toDatabase = function (prop, val) {
-    if (val === null) return 'NULL';
+    if (val === null) {
+		// Postgres complains with NULLs in not null columns
+		// If we have an autoincrement value, return DEFAULT instead
+        if( prop.autoIncrement ) {
+            return 'DEFAULT';
+        }
+        else {
+            return 'NULL';
+	    }
+    }
     if (val.constructor.name === 'Object') {
         var operator = Object.keys(val)[0]
         val = val[operator];
@@ -119,7 +128,14 @@ PG.prototype.toDatabase = function (prop, val) {
     }
     if (prop.type.name === 'Number') return val;
     if (prop.type.name === 'Date') {
-        if (!val) return 'NULL';
+        if (!val) {
+            if( prop.autoIncrement ) {
+                return 'DEFAULT';
+            }
+            else {
+                return 'NULL';
+            }
+        }
         if (!val.toUTCString) {
             val = new Date(val);
         }


### PR DESCRIPTION
PostgreSQL doesn't like NULLs in not null columns. Add a new option
autoIncrement, that when set makes the adapter insert DEFAULT instead of
NULL in those values.
