### PR TITLE
Enable connecting to Redis with URL

### DIFF
--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -11,11 +11,14 @@ exports.initialize = function initializeSchema(schema, callback) {
     if (schema.settings.url) {
         var url = require('url');
         var redisUrl = url.parse(schema.settings.url);
-        var redisAuth = redisUrl.auth.split(':');
+        var redisAuth = (redisUrl.auth || '').split(':');
         schema.settings.host = redisUrl.hostname;
         schema.settings.port = redisUrl.port;
-        schema.settings.db = redisAuth[0];
-        schema.settings.password = redisAuth[1];
+
+        if (redisAuth.length == 2) {
+            schema.settings.db = redisAuth[0];
+            schema.settings.password = redisAuth[1];
+        }
     }
 
     schema.client = redis.createClient(
@@ -23,7 +26,6 @@ exports.initialize = function initializeSchema(schema, callback) {
         schema.settings.host,
         schema.settings.options
     );
-
     schema.client.auth(schema.settings.password);
     schema.client.on('connect', callback);
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -48,6 +48,9 @@ function Schema(name, settings) {
     this.name = name;
     this.settings = settings;
 
+    // Disconnected by default
+    this.connected = false;
+
     // create blank models pool
     this.models = {};
     this.definitions = {};


### PR DESCRIPTION
Now the Redis adapter can also be connected to with a URL. So this works:

```
var schema = new Schema('redis', { url: process.env.REDISTOGO_URL });
```

Nice when using JugglingDB with [Heroku](https://devcenter.heroku.com/articles/nodejs), for instance.
