### PR TITLE
Fix 'undefined is not a function' problem at postgres adapter

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -46,7 +46,7 @@ PG.prototype.query = function (sql, callback) {
     var time = Date.now();
     var log = this.log;
     this.client.query(sql, function (err, data) {
-        log(sql, time);
+        if (log) log(sql, time);
         callback(err, data ? data.rows : null);
     });
 };


### PR DESCRIPTION
Currently, when using the Postgres adapter, there will be an "undefined is not a function" error shooting from lib/adapters/postgres.js:49 (`log(sql, time)`)

Referring to a similar structure at lib/adapters/mysql.js:70 and commit 8bb855c, it seems like a good idea to add it for Postgres as well.
