### PR TITLE
Exception when creating items with preset IDs

### DIFF
--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -87,9 +87,10 @@ BridgeToRedis.prototype.updateIndexes = function (model, id, data, callback) {
 };
 
 BridgeToRedis.prototype.create = function (model, data, callback) {
+    var log = this.logger('INCR id:' + model);
+
     if (data.id) return create.call(this, data.id, true);
 
-    var log = this.logger('INCR id:' + model);
     this.client.incr('id:' + model, function (err, id) {
         log();
         create.call(this, id);


### PR DESCRIPTION
Move the logger declaration up, to prevent it from crashing when creating items that already have ID's (usefull when loading fixtures in the DB)
