### PR TITLE
Postgres - Minor Fix

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -274,7 +274,7 @@ PG.prototype.autoupdate = function (cb) {
     var wait = 0;
     Object.keys(this._models).forEach(function (model) {
         wait += 1;
-        self.query('SELECT column_name as Field, udt_name as Type, is_nullable as Null, column_default as Default FROM information_schema.COLUMNS WHERE table_name = \''+ self.table(model) + '\'', function (err, fields) {
+        self.query('SELECT column_name as "Field", udt_name as "Type", is_nullable as "Null", column_default as "Default" FROM information_schema.COLUMNS WHERE table_name = \''+ self.table(model) + '\'', function (err, fields) {
             self.alterTable(model, fields, done);
         });
     });


### PR DESCRIPTION
Postgres doesn't honor case sensitivity unless fields/table names are double quoted.  I made a fix in this regard, but the related tests (automigrate/autoupdate) are in pretty bad shape for Postgres so I don't have them passing yet.  There are outstanding issues with the ALTER table functionality, but this change is enough for me to get my tables generated based on the models, and I'll be making the Postgres adapter more solid as I come across use cases in my application.
