### PR TITLE
Fix belongsTo relationships when fk is null

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -714,11 +714,7 @@ AbstractClass.belongsTo = function (anotherClass, params) {
     this.prototype['__finders__'][methodName] = function (id, cb) {
         anotherClass.find(id, function (err,inst) {
             if (err) return cb(err);
-            if (inst === null || inst[fk] === this.id) {
-                cb(null, inst);
-            } else {
-                cb(new Error('Permission denied'));
-            }
+            cb(null, inst);
         }.bind(this));
     }
 


### PR DESCRIPTION
When the fk was null, it was printing really obscure errors.  I think perhaps the find method on hasMany and the (async) getter of belongsTo should both work slightly differently.  I haven't implemented this yet, but will if you agree with me:

hasMany -> find

``` javascript
//If the instance is null, just return null to match find elsewhere.
if (inst === null || inst[fk] == this.id) {
    cb(null, inst);
} else {
    cb(new Error('Permission denied'));
}
```

belongsTo(callback)

``` javascript
//throw a proper not found error if that happens, not something un-intelligable,
//if the id is null, then it's not an error, this entity just doesn't belong to anyone

this.prototype['__finders__'][methodName] = function (id, cb) {
    if(id === null || id === undefined) return cb(null, null);
    anotherClass.find(id, function (err,inst) {
        if (err) return cb(err);
        if (!inst) return cb(new Error('Not found'));
        cb(null, inst);
    }.bind(this));
}
```
