### PR TITLE
Fix PostgreSQL query offset (issue #83)

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -261,7 +261,7 @@ PG.prototype.toFilter = function (model, filter) {
     }
 
     if (filter.limit) {
-        out += ' LIMIT ' + filter.limit + ' ' + (filter.offset || '');
+        out += ' LIMIT ' + filter.limit + ' OFFSET ' + (filter.offset || '');
     }
 
     return out;


### PR DESCRIPTION
Fixes issue #83 by including the OFFSET keyword in PostgreSQL queries.
