### PR TITLE
JugglingDB MongoDB Save Inserts only ID to database

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -63,7 +63,7 @@ MongoDB.prototype.create = function (model, data, callback) {
 };
 
 MongoDB.prototype.save = function (model, data, callback) {
-    this.collection(model).save({_id: new ObjectID(data.id)}, data, function (err) {
+    this.collection(model).update({_id: new ObjectID(data.id)}, data, function (err) {
         callback(err);
     });
 };


### PR DESCRIPTION
Fixes issue where only id would be saved when updating an existing object for mongodb driver.

.save instead of .update was being called which would persist only a
data object with the id value to the database on doing a save of an
existing object.

Using the native MongoDB driver whenever you try to update an object and then call save() the entry in MongoDB is only ever the ID. All other fields are removed.

Eg:

```
post = new Post()
post.title = "Title1"
post.save(c)
```

Gives entry in MongoDB with title = "Title1"

Then:

```
post.title = "Title 2"
post.save(c)
```

Will result in an entry with only
`{ "_id" : ObjectId( "4ff391abf2fae74460000001" ) }`

From my investigation it appears that the MongoDB driver is calling 

`this.collection(model).save`
with the
`this.collection(model).update`
variable format.

The save function only takes a single JSON object.

From the Mongo Docs:

```
> // x is some JSON style object
> db.mycollection.save(x); // updates if exists; inserts if new
> 
> // equivalent to:
> db.mycollection.update( { _id: x._id }, x, /*upsert*/ true );
```
