### PR TITLE
Adds Replica Set Support to JugglingDB Mongoose Adapter

### DIFF
--- a/lib/adapters/mongoose.js
+++ b/lib/adapters/mongoose.js
@@ -29,7 +29,12 @@ exports.initialize = function initializeSchema(schema, callback) {
         url = 'mongodb://' + url;
         schema.settings.url = url;
     }
-    schema.client = mongoose.connect(schema.settings.url);
+    if (!schema.settings.rs) {
+        schema.client = mongoose.connect(schema.settings.url);
+    } else {
+        schema.client = mongoose.connectSet(schema.settings.url, {rs_name: schema.settings.rs});
+    }
+    
     schema.adapter = new MongooseAdapter(schema.client);
     process.nextTick(callback);
 };


### PR DESCRIPTION
I have added a single property to the database.json object to take advantage of the replica set url format of Mongoose for Mongodb.

I am using railwayjs + juggling db in production with the Mongoose driver and a MongoDB replica set.

The change enables the addition of an rs: property with the replica set name

```
, "production":
  { 
    "driver":   "mongoose",
    "rs":       "my_replica_set",
    "url":      "mongodb://localhost:27017/db,mongodb://localhost:27018,mongodb://localhost:27019"
  }
```

I am happy to discuss the format of the json object and code if this seems out of place with the rest of the project.
