### PR TITLE
Mongodb native driver replicaset and authentication

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -11,19 +11,43 @@ exports.initialize = function initializeSchema(schema, callback) {
 
     var s = schema.settings;
 
-    if (schema.settings.url) {
-        var url = require('url').parse(schema.settings.url);
-        s.host = url.hostname;
-        s.port = url.port;
-        s.database = url.pathname.replace(/^\//, '');
-        s.username = url.auth && url.auth.split(':')[0];
-        s.password = url.auth && url.auth.split(':')[1];
+    if (schema.settings.rs) {
+
+        s.rs = schema.settings.rs;
+        if (schema.settings.url) {
+            var uris = schema.settings.url.split(',');
+            s.hosts = []
+            s.ports = []
+            uris.forEach(function(uri) {
+                var url = require('url').parse(uri);
+
+                s.hosts.push(url.hostname || 'localhost');
+                s.ports.push(parseInt(url.port || '27017', 10));
+
+                if (!s.database) s.database = url.pathname.replace(/^\//, '');
+                if (!s.username) s.username = url.auth && url.auth.split(':')[0];
+                if (!s.password) s.password = url.auth && url.auth.split(':')[1];    
+            });
+        }
+
+        s.database = s.database || 'test';
+
+    } else {
+
+        if (schema.settings.url) {
+            var url = require('url').parse(schema.settings.url);
+            s.host = url.hostname;
+            s.port = url.port;
+            s.database = url.pathname.replace(/^\//, '');
+            s.username = url.auth && url.auth.split(':')[0];
+            s.password = url.auth && url.auth.split(':')[1];
+        }
+
+        s.host = s.host || 'localhost';
+        s.port = parseInt(s.port || '27017', 10);
+        s.database = s.database || 'test';
+
     }
-
-    s.host = s.host || 'localhost';
-    s.port = parseInt(s.port || '27017', 10);
-    s.database = s.database || 'test';
-
     schema.adapter = new MongoDB(s, schema, callback);
 };
 
@@ -31,10 +55,20 @@ function MongoDB(s, schema, callback) {
     this._models = {};
     this.collections = {};
 
-    var server = new mongodb.Server(s.host, s.port, {});
+    var server;
+    if (s.rs) {
+        set = [];
+        for(i=0, n=s.hosts.length; i<n; i++) {
+            set.push(new mongodb.Server(s.hosts[i], s.ports[i], {auto_reconnect: true}));
+        }
+        server = new mongodb.ReplSetServers(set, {rs_name:s.rs});
+
+    } else {
+        server = new mongodb.Server(s.host, s.port, {});
+    }
+
     new mongodb.Db(s.database, server, {}).open(function (err, client) {
         if (err) throw err;
-        
         if (s.username && s.password) {
             t = this;
             client.authenticate(s.username, s.password, function(err, result) {
@@ -43,7 +77,7 @@ function MongoDB(s, schema, callback) {
               schema.client = client;
               callback();
             });
-            
+
         } else {
             this.client = client;
             schema.client = client;
@@ -198,4 +232,3 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, cb) {
 MongoDB.prototype.disconnect = function () {
     this.client.close();
 };
-


### PR DESCRIPTION
As per the conversation in the other ticket, I have added rudimentary auth and replica set support to the mongodb native driver.

I'm currently testing these fixes in the staging environment and it seems to be working well.

Your input on structure/inclusion would be appreciated. I tested the auth well and found no issues separately to the replica set inclusions.

Feel free to copy the auth code independently of the replica set stuff.

Cheers

As an aside - migrating from the mongoose.js driver to the mongodb driver introduced some interesting issues. It may be worthwhile for a long term strategy to include some migration code rather than attempting to make both function the same.
1. collection names changed from lowercase plural to uppercase singular (posts to Post)
2. all relationship id's changed from ObjectID() to String
