### PR TITLE
add quotes around key to allow mixed-case to work correctly

### DIFF
--- a/lib/adapters/postgres.js
+++ b/lib/adapters/postgres.js
@@ -237,7 +237,7 @@ PG.prototype.toFilter = function (model, filter) {
                     fields.push('"' + key + '" IS ' + filterValue);
                 } else if (conds[key].constructor.name === 'Object') {
                     var condType = Object.keys(conds[key])[0];
-                    var sqlCond = key;
+                    var sqlCond = '"' + key + '"';
                     switch (condType) {
                         case 'gt':
                             sqlCond += ' > ';


### PR DESCRIPTION
This resolves issue #126 - fix to add quotes around key so that it works for mixed-case correctly
