### PR TITLE
cradle limit + skip

### DIFF
--- a/lib/adapters/cradle.js
+++ b/lib/adapters/cradle.js
@@ -260,9 +260,15 @@ CradleAdapter.prototype.count = function(model, callback, where) {
 };
 
 CradleAdapter.prototype.models = function(model, filter, callback, func) {
+    var limit = 99999999; // maybe there is a better way to do this?
+    var skip  = 0;
+    if (filter != null) {
+      limit = filter.limit || limit;
+      skip  = filter.skip ||skip;
+    }
+
     this.client.all(
-       // maybe there is a better way to do this?
-       {include_docs:true, limit: filter.limit == null ? 9999999999 : filter.limit, skip: filter.skip == null ? 0 : filter.skip},
+       {include_docs:true, limit: limit, skip: skip},
        errorHandler(callback, function(res, cb) {
           var docs = res.map(function(doc) {
              return idealize(doc); 


### PR DESCRIPTION
I noticed that the cradle .all query does not have a limit and skip filter, hopefully this could work?
