### PR TITLE
Fixed bug for IN on NOT IN - corrected

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -238,6 +238,10 @@ MySQL.prototype.all = function all(model, filter, callback) {
             } else if (conds[key].constructor.name === 'Object') {
                 var condType = Object.keys(conds[key])[0];
                 var sqlCond = keyEscaped;
+                if ((condType == 'inq' || condType == 'nin') && val.length == 0) {
+                    cs.push(condType == 'inq' ? 0 : 1);
+                    return true;
+                }
                 switch (condType) {
                     case 'gt':
                         sqlCond += ' > ';


### PR DESCRIPTION
When length of values for IN and NOT IN is 0, it causes an SQL error: "IN ()" and "NOT IN ()" doesn't work in MySQL.

I corrected my first pull request :
https://github.com/1602/jugglingdb/pull/135
