### PR TITLE
update mongodb adapter

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -49,6 +49,9 @@ exports.initialize = function initializeSchema(schema, callback) {
         s.database = s.database || 'test';
 
     }
+
+    s.safe = s.safe || false;
+
     schema.adapter = new MongoDB(s, schema, callback);
 };
 
@@ -69,7 +72,7 @@ function MongoDB(s, schema, callback) {
         server = new mongodb.Server(s.host, s.port, {});
     }
 
-    new mongodb.Db(s.database, server, {}).open(function (err, client) {
+    new mongodb.Db(s.database, server, { safe: s.safe }).open(function (err, client) {
         if (err) throw err;
         if (s.username && s.password) {
             t = this;


### PR DESCRIPTION
when using the mongodb adapter, I was getting the following message on my console:

```
Please ensure that you set the default safe variable to one of the
allowed values of [true | false | {j:true} | {w:n, wtimeout:n} | {fsync:true}]
the default value is false which means the driver receives does not
return the information of the success/error of the insert/update/remove

ex: new Db(new Server('localhost', 27017), {safe:false})

http://www.mongodb.org/display/DOCS/getLastError+Command

The default of false will change to true in the near future

This message will disappear when the default safe is set on the driver Db
```

There was no way to pass the safe option to the jugglingdb mongodb adapter, so I modified the adapter to implement the ability to pass a 'safe' option, with a default of false, which was already the default it would set after giving you the warning message. By explicitly setting it to a value, this removes the warning, which only occurs if safe is undefined.

examples:

```
// no need to change your code as existing method still works fine
var schema = new Schema('mongodb', { url: 'mongodb://localhost' })

// driver will ensure writes have no errors before returning (slower)
var schema = new Schema('mongodb', { url: 'mongodb://localhost', safe: true });

// recommended for highly critical writes
var schema = new Schema('mongodb', { url: 'mongodb://localhost', safe: { j:true, w:'majority', wtimeout:10000 }})
```

You can set safe to any of the values mentioned in the message above. More info can be found here:http://www.mongodb.org/display/DOCS/getLastError+Command.
