### PR TITLE
cradle fix for railwayjs

### DIFF
--- a/lib/railway.js
+++ b/lib/railway.js
@@ -28,27 +28,31 @@ if (existsSync(confFile)) {
 
 var schema = new Schema(config && config.driver || 'memory', config);
 schema.log = log;
-railway.orm._schemas.push(schema);
 
-context = prepareContext(schema);
+// when using cradle if we dont wait for the schema to be connected, the models fails to load correctly.
+schema.on('connected', function() {
+    railway.orm._schemas.push(schema);
+
+    context = prepareContext(schema);
 
 // run schema first
-var schemaFile = (root || app.root) + '/db/schema.';
-if (existsSync(schemaFile + 'js')) {
-    schemaFile += 'js';
-} else if (existsSync(schemaFile + 'coffee')) {
-    schemaFile += 'coffee';
-} else {
-    schemaFile = false;
-}
+    var schemaFile = (root || app.root) + '/db/schema.';
+    if (existsSync(schemaFile + 'js')) {
+        schemaFile += 'js';
+    } else if (existsSync(schemaFile + 'coffee')) {
+        schemaFile += 'coffee';
+    } else {
+        schemaFile = false;
+    }
 
-if (schemaFile) {
-    railway.utils.runCode(schemaFile, context);
-}
+    if (schemaFile) {
+        railway.utils.runCode(schemaFile, context);
+    }
 
 // and freeze schemas
-railway.orm._schemas.forEach(function (schema) {
-    schema.freeze();
+    railway.orm._schemas.forEach(function (schema) {
+        schema.freeze();
+    });
 });
 
 // check validations and display warning


### PR DESCRIPTION
when using the cradle driver in a railwayjs app, the models failed to load as the schema was not properly connected before attempting to load the models.
