### PR TITLE
Fix crash when Redis2 adapter was unable to connect to the database

### DIFF
--- a/lib/adapters/redis2.js
+++ b/lib/adapters/redis2.js
@@ -42,6 +42,9 @@ exports.initialize = function initializeSchema(schema, callback) {
             }
         }
     });
+    schema.client.on('error', function (error) {
+        console.log(error);
+    })
 
     var clientWrapper = new Client(schema.client);
 


### PR DESCRIPTION
Now the error should be logged instead of redis module crashing on unhandled error.
