### PR TITLE
Urgent Bugfix for Railway+CoffeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ doc
 coverage.html
 coverage
 v8.log
+
+.DS_Store

--- a/lib/railway.js
+++ b/lib/railway.js
@@ -41,7 +41,6 @@ module.exports = function init(root) {
             console.log('Could not parse config/database.yml');
             throw e;
         }
-        config = {};
     }
     // when driver name started with point - look for driver in app root (relative path)
     if (config.driver && config.driver.match(/^\./)) {


### PR DESCRIPTION
Removed a bogus line that was resetting the configuration read from
"database.yml", the file that's used instead of "database.json" when
railway gets initialized using --coffee, as this was preventing Railway
to work with any database driver other than Memory.
