### PR TITLE
added LIKE filter

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -208,7 +208,16 @@ MySQL.prototype.all = function all(model, filter, callback) {
 
         if (filter.where) {
             sql += ' ' + buildWhere(filter.where);
+			if (filter.like) {
+				sql += ' AND ' + buildLike(filter.like);
+			}
         }
+		
+		else {
+			if (filter.like) {
+				sql += ' WHERE ' + buildLike(filter.like);
+			}
+		}
 
         if (filter.order) {
             sql += ' ' + buildOrderBy(filter.order);
@@ -281,6 +290,19 @@ MySQL.prototype.all = function all(model, filter, callback) {
           return '';
         }
         return 'WHERE ' + cs.join(' AND ');
+    }
+	
+	function buildLike(conds) {
+        var cs = [];
+        Object.keys(conds).forEach(function (key) {
+            var keyEscaped = '`' + key.replace(/\./g, '`.`') + '`'
+            var val = self.toDatabase(props[key], conds[key]);
+			cs.push(keyEscaped, val);
+        });
+        if (cs.length === 0) {
+          return '';
+        }
+        return '' + cs[0] +  ' LIKE ' + cs[1];
     }
 
     function buildOrderBy(order) {


### PR DESCRIPTION
This is the first node project I got involved with, so please look over the code and give me feedback if this is a bad practice somehow.

this works both as:
`Comment.all({ where : {'id' : '77'},  like : {'comment_author' :
'%casino%'}, limit: 100}`
and also:
`Comment.all({ like : {'comment_author' : '%casino%'}, limit: 100}`
