### PR TITLE
allow socketPath for mysql config

### DIFF
--- a/lib/adapters/mysql.js
+++ b/lib/adapters/mysql.js
@@ -15,7 +15,8 @@ exports.initialize = function initializeSchema(schema, callback) {
         port: s.port || 3306,
         user: s.username,
         password: s.password,
-        debug: s.debug
+        debug: s.debug,
+        socketPath: s.socketPath
     });
 
     schema.adapter = new MySQL(schema.client);


### PR DESCRIPTION
As supported here: https://github.com/felixge/node-mysql/blob/master/lib/Connection.js#L24

This allows the passing of an optional `socketPath` configuration option for the mysql config.
