### PR TITLE
let the adapter decide when to load the schema

### DIFF
--- a/lib/adapters/cradle.js
+++ b/lib/adapters/cradle.js
@@ -145,6 +145,8 @@ function filtering(res, model, filter, instance) {
 exports.initialize = function(schema, callback) {
     if (!cradle) return;
 
+    // when using cradle if we dont wait for the schema to be connected, the models fails to load correctly.
+    schema.waitForConnect = true;
     if (!schema.settings.url) {
         var host = schema.settings.host || 'localhost';
         var port = schema.settings.port || '5984';

--- a/lib/railway.js
+++ b/lib/railway.js
@@ -49,36 +49,14 @@ module.exports = function init(root) {
 
     var schema = new Schema(config && config.driver || 'memory', config);
     schema.log = log;
-    // when using cradle if we dont wait for the schema to be connected, the models fails to load correctly.
-    schema.on('connected', function() {
-        railway.orm._schemas.push(schema);
 
-        var context = prepareContext(models, railway, app, schema);
-
-        // run schema first
-        var schemaFile = (root || app.root) + '/db/schema.';
-        if (existsSync(schemaFile + 'js')) {
-            schemaFile += 'js';
-        } else if (existsSync(schemaFile + 'coffee')) {
-            schemaFile += 'coffee';
-        } else {
-            schemaFile = false;
-        }
-
-        if (schemaFile) {
-            var code = fs.readFileSync(schemaFile).toString();
-            if (schemaFile.match(/\.coffee$/)) {
-                code = require('coffee-script').compile(code);
-            }
-            var fn = new Function('context', 'require', 'with(context){(function(){' + code + '})()}');
-            fn(context, require);
-        }
-
-        // and freeze schemas
-        railway.orm._schemas.forEach(function (schema) {
-            schema.freeze();
+    if (schema.waitForConnect) {
+        schema.on('connected', function() {
+            loadSchema(schema, railway, app, models);
         });
-    });
+    } else {
+        loadSchema(schema, railway, app, models);
+    }
 
 // check validations and display warning
 
@@ -93,6 +71,36 @@ Object.keys(models).forEach(function (model) {
 if (displayWarning) {
     var $ = railway.utils.stylize.$;
     // require('util').puts($('WARNING:').bold.red + ' ' + $('I can see that you\'ve added validation to db/schema.js. However schema.js file is only used to describe database schema. Therefore validations configured in db/schema.js will be ignored.\nFor business logic (incl. validations) please create models as separate .js files here: app/models/*.js').yellow);
+}
+
+function loadSchema(schema, railway, app, models) {
+    railway.orm._schemas.push(schema);
+
+    var context = prepareContext(models, railway, app, schema);
+
+    // run schema first
+    var schemaFile = (root || app.root) + '/db/schema.';
+    if (existsSync(schemaFile + 'js')) {
+        schemaFile += 'js';
+    } else if (existsSync(schemaFile + 'coffee')) {
+        schemaFile += 'coffee';
+    } else {
+        schemaFile = false;
+    }
+
+    if (schemaFile) {
+        var code = fs.readFileSync(schemaFile).toString();
+        if (schemaFile.match(/\.coffee$/)) {
+            code = require('coffee-script').compile(code);
+        }
+        var fn = new Function('context', 'require', 'with(context){(function(){' + code + '})()}');
+        fn(context, require);
+    }
+
+    // and freeze schemas
+    railway.orm._schemas.forEach(function (schema) {
+        schema.freeze();
+    });
 }
 
 function log(str, startTime) {


### PR DESCRIPTION
Since you are putting all adapters into separate repositories, I'd like to let the adapter decide whether jugglingdb should wait a connect before loading the schema. fa50e0e broke support for MySQL, this pull request fixes it.
