### PR TITLE
add additional types stored in Schema.types to schema context

### DIFF
--- a/lib/railway.js
+++ b/lib/railway.js
@@ -201,6 +201,15 @@ function prepareContext(models, railway, app, defSchema, done) {
         if (cname) settings[cname].table = name;
     };
 
+    /**
+     * If the Schema has additional types, add them to the context
+     * e.g. MySQL has an additional Point type
+     */
+    if (Schema.types && Object.keys(Schema.types).length) {
+        for (var typeName in Schema.types) {
+            ctx[typeName] = Schema.types[typeName];
+        }
+    }
     ctx.Text = Schema.Text;
 
     return ctx;


### PR DESCRIPTION
This will look for the `types` property in the Schema class and add them to the schema context. This allows adapters to add additional types which can then be used in the schema. (See my jugglingdb-mysql pull request for an example)
