### PR TITLE
updateAttributes: data defaults to {}

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -721,6 +721,8 @@ AbstractClass.prototype.updateAttributes = function updateAttributes(data, cb) {
     var inst = this;
     var model = this.constructor.modelName;
 
+    if(!data) data = {};
+
     // update instance's properties
     Object.keys(data).forEach(function (key) {
         inst[key] = data[key];


### PR DESCRIPTION
If the first argument of updateAttribuets is undefined / null, an exception is thrown. This fixes it
