### PR TITLE
.include does not always invoke callback

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -440,6 +440,8 @@ AbstractClass.include = function (objects, include, cb) {
                     cb(null, objects);
                 }
             });
+        } else {
+            cb(null, objects);
         }
     }
 


### PR DESCRIPTION
In AbstractClass.include, there is a path for which the callback is never invoked.

This was causing bad result sets in the case for where I had many-to-many relationships and wrote a nested include, but there were no actual relationships established.

To recreate: 

``` javascript
//simplified models
var Tests = schema.define('search_tests', {
        id:Number,
        name: String
    });

var Features = schema.define('search_features', {
        id:Number,
        name: String
    });

var Test_Feature_Xref = schema.define('search_tests_mm_features', {
        id: Number,
        test_id: Number,
        feature_id: Number
    });
SearchTests.hasMany(Test_Feature_Xref, {as:'_features', foreignKey:'test_id'});
Test_Feature_Xref.belongsTo(SearchFeatures, {as:'_features', foreignKey:'feature_id'});

```

Example query:

``` javascript
//searchProvider is another relationship not actually shown in the example models- can be ignored
SearchTests.all({include:['_searchProvider', {_features:'_features'}]}, console.log);
```

In this case if the Xref table has some data, then it works fine. However, if the Xref table were empty because there are no tests with features currently, then the include function will end up processing `processIncludeItem([], ...)` which results in a null function. In this path cb() is never invoked, and it ends up ruining the final data set.
