### PR TITLE
Changes to make type flexibility in various DB engines easier.

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -87,7 +87,9 @@ AbstractClass.prototype._initProperties = function (data, applySetters) {
         var type = properties[attr].type;
 
         if (BASE_TYPES.indexOf(type.name) === -1) {
-            if (typeof self.__data[attr] !== 'object' && self.__data[attr]) {
+            if (type.hasOwnProperty('parse')) {
+                self.__data[attr] = type.parse(self.__data[attr]);
+            } else if (typeof self.__data[attr] !== 'object' && self.__data[attr]) {
                 try {
                     self.__data[attr] = JSON.parse(self.__data[attr] + '');
                 } catch (e) {
@@ -717,7 +719,7 @@ AbstractClass.prototype.destroy = function (cb) {
     this.trigger('destroy', function (destroyed) {
         this._adapter().destroy(this.constructor.modelName, this.id, function (err) {
             destroyed(function () {
-                if(cb) cb(err);
+                if (cb) cb(err);
             });
         }.bind(this));
     });
@@ -753,7 +755,7 @@ AbstractClass.prototype.updateAttributes = function updateAttributes(data, cb) {
     var inst = this;
     var model = this.constructor.modelName;
 
-    if(!data) data = {};
+    if (!data) data = {};
 
     // update instance's properties
     Object.keys(data).forEach(function (key) {
@@ -1098,13 +1100,13 @@ function defineScope(cls, targetClass, name, params, methods) {
                 cb(err);
             } else {
                 (function loopOfDestruction (data) {
-                    if(data.length > 0) {
+                    if (data.length > 0) {
                         data.shift().destroy(function(err) {
-                            if(err && cb) cb(err);
+                            if (err && cb) cb(err);
                             loopOfDestruction(data);
                         });
                     } else {
-                        if(cb) cb();
+                        if (cb) cb();
                     }
                 }(data));
             }
@@ -1129,7 +1131,6 @@ function defineScope(cls, targetClass, name, params, methods) {
 AbstractClass.prototype.inspect = function () {
     return util.inspect(this.__data, false, 4, true);
 };
-
 
 /**
  * Check whether `s` is not undefined

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -57,6 +57,8 @@ function Schema(name, settings) {
     // create blank models pool
     this.models = {};
     this.definitions = {};
+    
+    this.types = {}; // Blank types object.
 
     // and initialize schema using adapter
     // this is only one initialization entry point of adapter


### PR DESCRIPTION
I've made a pull request for the MySQL back end that makes the reason for this pull request more clear. I've added the ability for the storage back ends to define types, but I've done so in a way that differs a little bit from how it's working right now with Point.
