### PR TITLE
This is the smash with blunt object fix for #215

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -91,7 +91,7 @@ AbstractClass.prototype._initProperties = function (data, applySetters) {
                 try {
                     self.__data[attr] = JSON.parse(self.__data[attr] + '');
                 } catch (e) {
-                    console.log(e.stack);
+                    self.__data[attr] = String(self.__data[attr]);
                 }
             }
             if (type.name === 'Array' || typeof type === 'object' && type.constructor.name === 'Array') {


### PR DESCRIPTION
This is the smash with blunt object fix for #215, since the more flexible #213 was rejected.

There needs to be something done so that types not in `BASE_TYPES` can be parsed without
throwing an exception and making things go nuts when they aren't JSON.

As noted this is the blunt object solution and will not cover all cases, but something needs to be done.
