### PR TITLE
http adapter: pre/postProcess, fix destroy and all

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -9,8 +9,59 @@ function WebService() {
     this.ids = {};
 }
 
+WebService.prototype.installPostProcessor = function installPostProcessor(descr) {
+    var dates = [];
+    Object.keys(descr.properties).forEach(function(column) {
+        if (descr.properties[column].type.name === 'Date') {
+            dates.push(column);
+        }
+    });
+
+    var postProcessor = function(model) {
+        var max = dates.length;
+        for (var i = 0; i < max; i++) {
+            var column = dates[i];
+            if (model[column]) {
+                model[column] = new Date(model[column]);
+            }
+        };
+    };
+
+    descr.postProcessor = postProcessor;
+};
+
+WebService.prototype.preProcess = function preProcess(data) {
+    var result = {};
+    Object.keys(data).forEach(function(key) {
+        if (data[key] != null) {
+            result[key] = data[key];
+        }
+    })
+    return result;
+};
+
+WebService.prototype.postProcess = function postProcess(model, data) {
+    var postProcessor = this._models[model].postProcessor;
+    if (postProcessor && data) {
+        postProcessor(data);
+    }
+};
+
+WebService.prototype.postProcessMultiple = function postProcessMultiple(model, data) {
+    var postProcessor = this._models[model].postProcessor;
+    if (postProcessor) {
+        var max = data.length;
+        for (var i = 0; i < max; i++) {
+            if (data[i]) {
+                postProcessor(data[i]);
+            }
+        };
+    }
+};
+
 WebService.prototype.define = function defineModel(descr) {
     var m = descr.model.modelName;
+    this.installPostProcessor(descr);
     this._models[m] = descr;
 };
 
@@ -32,7 +83,7 @@ WebService.prototype.getBlankReq = function () {
 
 WebService.prototype.create = function create(model, data, callback) {
     var req = this.getBlankReq();
-    req[model] = data;
+    req[model] = this.preProcess(data);
     $.post(this.getResourceUrl(model) + '.json', req, function (res) {
         if (res.code === 200) {
             callback(null, res.data.id);
@@ -58,11 +109,13 @@ WebService.prototype.updateOrCreate = function (model, data, callback) {
 };
 
 WebService.prototype.save = function save(model, data, callback) {
+    var _this = this;
     var req = this.getBlankReq();
     req._method = 'PUT';
-    req[model] = data;
+    req[model] = this.preProcess(data);
     $.post(this.getResourceUrl(model) + '/' + data.id + '.json', req, function (res) {
         if (res.code === 200) {
+            _this.postProcess(model, res.data);
             callback(null, res.data);
         } else {
             callback(res.error);
@@ -83,8 +136,10 @@ WebService.prototype.exists = function exists(model, id, callback) {
 };
 
 WebService.prototype.find = function find(model, id, callback) {
+    var _this = this;
     $.getJSON(this.getResourceUrl(model) + '/' + id + '.json', function (res) {
         if (res.code === 200) {
+            _this.postProcess(model, res.data);
             callback(null, res.data);
         } else {
             callback(res.error);
@@ -93,13 +148,24 @@ WebService.prototype.find = function find(model, id, callback) {
 };
 
 WebService.prototype.destroy = function destroy(model, id, callback) {
-    delete this.cache[model][id];
-    callback();
+    var _this = this;
+    var req = this.getBlankReq();
+    req._method = 'DELETE';
+    $.post(this.getResourceUrl(model) + '/' + id + '.json', req, function (res) {
+        if (res.code === 200) {
+            //delete _this.cache[model][id];
+            callback(null, res.data);
+        } else {
+            callback(res.error);
+        }
+    }, 'json');
 };
 
 WebService.prototype.all = function all(model, filter, callback) {
-    $.getJSON(this.getResourceUrl(model) + '.json?query=' + JSON.stringify(filter), function (res) {
+    var _this = this;
+    $.getJSON(this.getResourceUrl(model) + '.json?query=' + encodeURIComponent(JSON.stringify(filter)), function (res) {
         if (res.code === 200) {
+            _this.postProcessMultiple(model, res.data);
             callback(null, res.data);
         } else {
             callback(res.error);


### PR DESCRIPTION
preProcess() ensures that null fields are excluded from the wire. I've experienced jQuery/node/express 3.0 turning nulls into empty strings on the server.

postProcess() ensures that Date fields are actually turned back into dates. JSON, you're annoying sometimes.

destroy() is now implemented.

all() now URL encodes any query filters provided.
