### PR TITLE
allow specifying localKey in hasMany and belongsTo relationships

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -849,13 +849,20 @@ AbstractClass.prototype.reset = function () {
  * @param {Object} params - configuration {as:, foreignKey:}
  * @example `User.hasMany(Post, {as: 'posts', foreignKey: 'authorId'});`
  */
-AbstractClass.hasMany = function hasMany(anotherClass, params) {
+AbstractClass.hasMany = function (anotherClass, params) {
     var methodName = params.as; // or pluralize(anotherClass.modelName)
     var fk = params.foreignKey;
 
+    var localKey = "id";
+    if (params.localKey) {
+        localKey = params.localKey;
+    } else if (this.schema.adapter.tableNameID) {
+        localKey = this.modelName + "ID";
+    }
+
     this.relations[params['as']] = {
         type: 'hasMany',
-        keyFrom: 'id',
+        keyFrom: localKey,
         keyTo: params['foreignKey'],
         modelTo: anotherClass,
         multiple: true
@@ -927,10 +934,17 @@ AbstractClass.belongsTo = function (anotherClass, params) {
     var methodName = params.as;
     var fk = params.foreignKey;
 
+    var localKey = "id";
+    if (params.localKey) {
+        localKey = params.localKey;
+    } else if (anotherClass.schema.adapter.tableNameID) {
+        localKey = anotherClass.modelName + "ID";
+    }
+
     this.relations[params['as']] = {
         type: 'belongsTo',
         keyFrom: params['foreignKey'],
-        keyTo: 'id',
+        keyTo: localKey,
         modelTo: anotherClass,
         multiple: false
     };


### PR DESCRIPTION
There was already the ability to specify the "foreignKey" in a relationship.  However, there was no way to specify the "localKey" in a situation where the key on the other side of the relationship is not the standard "id" field.  This change simply looks in the params object for a "localKey" string which it then uses in place of the "id" field.  If no localKey is specifed "id" is used.
