### PR TITLE
[model - belongsTo] Changing the comparison of id and fk of belongsTo function.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -959,7 +959,7 @@ AbstractClass.belongsTo = function (anotherClass, params) {
         anotherClass.find(id, function (err,inst) {
             if (err) return cb(err);
             if (!inst) return cb(null, null);
-            if (inst.id == this[fk]) {
+            if (inst.id === this[fk]) {
                 cb(null, inst);
             } else {
                 cb(new Error('Permission denied'));

--- a/test/mongodb.test.coffee
+++ b/test/mongodb.test.coffee
@@ -1,0 +1,40 @@
+Schema = require('../').Schema
+should = require 'should'
+db     = new Schema 'mongodb', url: 'mongodb://localhost/jugglingdb'
+
+describe 'mongodb', ->
+    List = null
+    Todo = null
+    ListLocal = null
+
+    before ->
+        List = db.define 'List', 
+            title: 
+                type: String
+            TodoId: 
+                type: Number
+
+        Todo = db.define 'Todo',
+            title:
+                type: String
+
+        List.belongsTo Todo, as: 'categorized', foreignKey: 'TodoId'
+
+
+    it 'should set Todo relation', (done) ->
+        Todo.create title: 'Funny list', (err, oTodo) ->
+            (oTodo instanceof Todo).should.ok
+            (oTodo.title).should.equal 'Funny list'
+            
+            List.create title: 'Drink with friends', TodoId: oTodo.id, (err, oList) ->
+                (oList instanceof List).should.ok
+                (oList.title).should.equal 'Drink with friends', 'The title of my todo is done'
+
+                ListLocal = oList
+                done()
+
+    it 'should get Todo relation', (done) ->
+        ListLocal.categorized (err, obj) ->
+            (!err).should.ok
+            
+            done()


### PR DESCRIPTION
I've tried to use belongsTo function with mongoDb Database.

``` coffeescript
Object.belongsTo Category, as: 'categorized',  foreignKey: 'categoryId'
@object.categorized (category_id, category) =>
    @category = category || []
```

When I call function, he return a "Permission denied" response.

So I've try to debug and I've found that:

``` javascript
typeof inst.id === object 
typeof this[fk] === string
```

I therefore think that comparison type is not usefull and I would like to suggest a fix.

Thanks.
