### PR TITLE
Fix the test case so that all() and findOne() uses the same filter

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -145,7 +145,7 @@ describe('basic-querying', function() {
 
         it('should find first record (default sort by id)', function(done) {
             User.all({order: 'id'}, function(err, users) {
-                User.findOne(function(e, u) {
+                User.findOne({order: 'id'}, function(e, u) {
                     should.not.exist(e);
                     should.exist(u);
                     u.id.toString().should.equal(users[0].id.toString());


### PR DESCRIPTION
The patches fixes the test case so that all() and findOne() uses the same filter.
