### PR TITLE
Fix model.whatTypeName for [] since currently returns undefined

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -137,7 +137,7 @@ AbstractClass.whatTypeName = function (propName) {
         return null;
         // throw new Error('Undefined type for ' + this.modelName + ':' + propName);
     }
-    return prop.type.name;
+    return prop.type.name || typeof prop.type;
 };
 
 AbstractClass._forDB = function (data) {


### PR DESCRIPTION
calling model.whatTypeName() on an array [] field currently returns undefined. This results in array fields not being saved correctly since whatTypeName() is called from _forDB() which is called from save()
