### PR TITLE
Case to allow for objects as datatypes because you can't call a constructor as a function.

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -266,7 +266,7 @@ Schema.prototype.define = function defineClass(className, properties, settings) 
                 if (NewClass.setter[attr]) {
                     NewClass.setter[attr].call(this, value);
                 } else {
-                    if (value === null || value === undefined) {
+                    if (value === null || value === undefined || typeof DataType === 'object') {
                         this.__data[attr] = value;
                     } else {
                         this.__data[attr] = DataType(value);


### PR DESCRIPTION
Required for support of Enum in MySQL adapter because each Enum is its own Enum object instead of there being a universal Enum function.

Implemented in most simple way possible.
