### PR TITLE
Added extend function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ exports.extend = extend;
 
 function extend(target) {
     var sources = [].slice.call(arguments, 1);
-    sources.forEach(function (source) {
+    sources.forEach(function(source) {
         for (var prop in source) {
             target[prop] = source[prop];
         }


### PR DESCRIPTION
In case we don't use underscore, extend purpose is merge two object attributes.

Used in my AbstractClass.findOrCreate proposal.
