### PR TITLE
Extend findOrCreate() query param behavior

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -7,6 +7,7 @@ module.exports = AbstractClass;
  * Module dependencies
  */
 var util = require('util');
+var utils = require('./utils');
 var validations = require('./validations.js');
 var ValidationError = validations.ValidationError;
 var List = require('./list.js');
@@ -213,7 +214,7 @@ AbstractClass.create = function (data, callback) {
 
         function modelCreated() {
             if (--wait === 0) {
-                callback(gotError ? errors : null, instances);
+                callback(gotError ? errors : null, instances, true);  // indicate creation flag
             }
         }
     }
@@ -255,7 +256,7 @@ AbstractClass.create = function (data, callback) {
                     }
                     saveDone.call(obj, function () {
                         createDone.call(obj, function () {
-                            callback(err, obj);
+                            callback(err, obj, true);  // indicate creation flasg
                         });
                     });
                 }, obj);
@@ -313,13 +314,13 @@ AbstractClass.upsert = AbstractClass.updateOrCreate = function upsert(data, call
  * Find one record, same as `all`, limited by 1 and return object, not collection,
  * if not found, create using data provided as second argument
  * 
- * @param {Object} query - search conditions: {where: {test: 'me'}}.
+ * @param {Object} query - search conditions (where): {test: 'me'}.
  * @param {Object} data - object to create.
  * @param {Function} cb - callback called with (err, instance)
  */
 AbstractClass.findOrCreate = function findOrCreate(query, data, callback) {
     if (typeof query === 'undefined') {
-        query = {where: {}};
+        query = {};
     }
     if (typeof data === 'function' || typeof data === 'undefined') {
         callback = data;
@@ -333,7 +334,7 @@ AbstractClass.findOrCreate = function findOrCreate(query, data, callback) {
     this.findOne(query, function (err, record) {
         if (err) return callback(err);
         if (record) return callback(null, record);
-        t.create(data, callback);
+        t.create(utils.extend(query, data), callback);
     });
 };
 


### PR DESCRIPTION
In real world, the most common use of findOrCreate() is to simplify steps of getting a record or insert new if doesn't exist.

I propose to change query 'data' structure: remove 'query' key, so it's value is the query it self because:
1. Find will always a WHERE statement, no else.
2. This will simplify typo usage.
3. The where values mostly part of required data. So it is good to include where values as 'data' to be inserted if the data not exist.

Example usage:

``` javascript
function setData(key, value) {
    if (typeof value === 'object')
        value = JSON.stringify(value);

    // { key: key } is our where expression
    // In most cases the where keys is required, so query will merged to data as new data = { key: key, value: value } to automatically insert later if the data not exists.

    Data.findOrCreate({ key: key }, { value: value }, 
        function (err, record, created) {

            if (!created) {
                console.log('UPDATING EXISTING RECORD');

                record.value = value;
                record.save(function (err, record) {
                    console.log(err, record);
                });
            } else console.log('NEW RECORD INSERTED');
    });
}

setData('theKey', { name: 'A Name', date: new Date });
setData('another_Key', 'String Data');
setData('another_Key', 10000);
```
