### PR TITLE
Support separate field names used for storage.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -98,7 +98,19 @@ Examples of model definition:
         },
         activated: { type: Boolean, default: false }
     }, {
-        tableName: 'users'
+        table: 'users'
+    });
+
+#### Custom database column/field names
+
+You can store the data using a different field/column name by specifying the
+`name` property in the field definition.
+
+For example, to store `firstName` as `first_name`:
+
+    var User = schema.define('User', {
+      firstName: { type: String, name: 'first_name' },
+      lastName: { type: String, name: 'last_name' }
     });
 
 ### DB structure syncronization

--- a/lib/model.js
+++ b/lib/model.js
@@ -148,24 +148,69 @@ AbstractClass.whatTypeName = function (propName) {
  */
 AbstractClass.update = function (params, cb) {
     if (stillConnecting(this.schema, this, arguments)) return;
-    this.schema.adapter.update(this.modelName, params, cb);
+    var Model = this;
+    if (params && params.update) {
+      params.update = this._forDB(params.update);
+    }
+    this.schema.adapter.update(this.modelName, params, function(err, obj) {
+      cb(err, Model._fromDB(obj));
+    });
 };
 
-
+/**
+ * Prepares data for storage adapter.
+ *
+ * Ensures data is allowed by the schema, and stringifies JSON field types.
+ * If the schema defines a custom field name, it is transformed here.
+ *
+ * @param {Object} data
+ * @return {Object} Returns data for storage.
+ */
 AbstractClass._forDB = function (data) {
+    if (!data) return;
     var res = {};
+    var definition = this.schema.definitions[this.modelName].properties;
     Object.keys(data).forEach(function (propName) {
+        var val;
         var typeName = this.whatTypeName(propName);
         if (!typeName && !data[propName] instanceof Array) {
             return;
         }
         if (typeName === 'JSON' || data[propName] instanceof Array) {
-            res[propName] = JSON.stringify(data[propName]);
+            val = JSON.stringify(data[propName]);
         } else {
-            res[propName] = data[propName];
+            val = data[propName];
+        }
+        if (definition[propName].name) {
+          // Use different name for DB field/column
+          res[definition[propName].name] = val;
+        } else {
+          res[propName] = val;
         }
     }.bind(this));
     return res;
+};
+
+/**
+ * Unpacks data from storage adapter.
+ *
+ * If the schema defines a custom field name, it is transformed here.
+ *
+ * @param {Object} data
+ * @return {Object}
+ */
+AbstractClass._fromDB = function (data) {
+    if (!data) return;
+    var definition = this.schema.definitions[this.modelName].properties;
+    var propNames = Object.keys(data);
+    Object.keys(definition).forEach(function (defPropName) {
+      var customName = definition[defPropName].name;
+      if (customName && propNames.indexOf(customName) !== -1) {
+        data[defPropName] = data[customName];
+        delete data[customName];
+      }
+    });
+    return data;
 };
 
 AbstractClass.prototype.whatTypeName = function (propName) {
@@ -260,6 +305,7 @@ AbstractClass.create = function (data, callback) {
                         defineReadonlyProp(obj, 'id', id);
                     }
                     if (rev) {
+                        rev = Model._fromDB(rev);
                         obj._rev = rev
                     }
                     if (err) {
@@ -298,9 +344,10 @@ AbstractClass.upsert = AbstractClass.updateOrCreate = function upsert(data, call
     if (!data.id) return this.create(data, callback);
     if (this.schema.adapter.updateOrCreate) {
         var inst = new Model(data);
-        this.schema.adapter.updateOrCreate(Model.modelName, inst.toObject(true), function (err, data) {
+        this.schema.adapter.updateOrCreate(Model.modelName, Model._forDB(inst.toObject(true)), function (err, data) {
             var obj;
             if (data) {
+                data = inst._fromDB(data);
                 inst._initProperties(data);
                 obj = inst;
             } else {
@@ -374,9 +421,12 @@ AbstractClass.exists = function exists(id, cb) {
 AbstractClass.find = function find(id, cb) {
     if (stillConnecting(this.schema, this, arguments)) return;
 
+    var Model = this;
+
     this.schema.adapter.find(this.modelName, id, function (err, data) {
         var obj = null;
         if (data) {
+            data = Model._fromDB(data);
             if (!data.id) {
                 data.id = id;
             }
@@ -412,10 +462,15 @@ AbstractClass.all = function all(params, cb) {
         params = null;
     }
     var constr = this;
-    this.schema.adapter.all(this.modelName, params, function (err, data) {
+    var paramsFiltered = params;
+    if (params && params.where) {
+      paramsFiltered.where = this._forDB(paramsFiltered.where);
+    }
+    this.schema.adapter.all(this.modelName, paramsFiltered, function (err, data) {
         if (data && data.forEach) {
             data.forEach(function (d, i) {
                 var obj = new constr;
+                d = constr._fromDB(d);
                 obj._initProperties(d, false);
                 if (params && params.include && params.collect) {
                     data[i] = obj.__cachedRelations[params.collect];
@@ -480,7 +535,7 @@ AbstractClass.count = function (where, cb) {
         cb = where;
         where = null;
     }
-    this.schema.adapter.count(this.modelName, cb, where);
+    this.schema.adapter.count(this.modelName, cb, this._forDB(where));
 };
 
 /**

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -9,12 +9,12 @@ describe('manipulation', function() {
         db = getSchema();
 
         Person = db.define('Person', {
-            name: String,
+            name: {type: String, name: 'full_name'},
             gender: String,
             married: Boolean,
             age: {type: Number, index: true},
             dob: Date,
-            createdAt: {type: Number, default: Date.now}
+            createdAt: {type: Number, default: Date.now, name: 'created_at'}
         });
 
         db.automigrate(done);
@@ -174,6 +174,16 @@ describe('manipulation', function() {
                         'throws': true
                     });
                 }).should.throw('Validation error');
+            });
+        });
+
+        it('should save with custom fields', function() {
+            Person.create({name: 'Anatoliy'}, function(err, p) {
+              should.exist(p.id);
+              should.exist(p.name);
+              should.not.exist(p['full_name']);
+              var storedObj = JSON.parse(db.adapter.cache.Person[p.id]);
+              should.exist(storedObj['full_name']);
             });
         });
 


### PR DESCRIPTION
This closes #119 by adding support for storing data using a field name defined by the schema. 

For example, to store `emailAddress` as `email_address`, you use the `name` parameter:

```
var User = schema.define('User', {
  name: String,
  emailAddress: { type: String, name: 'email_address' }
});
```

I've added a test for it and updated documentation: https://github.com/alexmingoia/jugglingdb/blob/custom-fieldnames/docs/schema.md#custom-database-columnfield-names
