### PR TITLE
To set the table name, use `table`, not `tableName`

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -98,7 +98,7 @@ Examples of model definition:
         },
         activated: { type: Boolean, default: false }
     }, {
-        tableName: 'users'
+        table: 'users'
     });
 
 ### DB structure syncronization


### PR DESCRIPTION
Inspection of jugglingdb code (Schema.prototype.tableName) suggests the schema setting is `table`
