### PR TITLE
Text fields values don't persist

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -21,7 +21,7 @@ exports.Schema = Schema;
  */
 var slice = Array.prototype.slice;
 
-Schema.Text = function Text() {};
+Schema.Text = function Text(s) { return s; };
 Schema.JSON = function JSON() {};
 
 Schema.types = {};


### PR DESCRIPTION
Schema.Text() function returns empty value and this doesn't allow to persist values from Text fields.
