### PR TITLE
Fixed reading/writing arrays through model

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -52,18 +52,25 @@ function List(data, type, parent) {
         }
     }
 
-    data.forEach(function(item, i) {
-        data[i] = new Item(item, list);
-        Object.defineProperty(list, data[i].id, {
-            writable: true,
-            enumerable: false,
-            configurable: true,
-            value: data[i]
+    if (type.name === 'Array') {
+        //  We do not create Item objects for objects that were in array
+        //  as that converts the values into { id: value } objects which
+        //  corrupts the data both on reading and for further updating
+        //  in the database.
+    } else {
+        data.forEach(function(item, i) {
+            data[i] = new Item(item, list);
+            Object.defineProperty(list, data[i].id, {
+                writable: true,
+                enumerable: false,
+                configurable: true,
+                value: data[i]
+            });
+            if (list.nextid <= data[i].id) {
+                list.nextid = data[i].id + 1;
+            }
         });
-        if (list.nextid <= data[i].id) {
-            list.nextid = data[i].id + 1;
-        }
-    });
+    }
 
     Object.defineProperty(list, 'length', {
         enumerable: false,

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -286,6 +286,8 @@ Schema.prototype.define = function defineClass(className, properties, settings) 
             get: function () {
                 if (NewClass.getter[attr]) {
                     return NewClass.getter[attr].call(this);
+                } else if(DataType === Array) {
+                    return this.__data[attr].items;
                 } else {
                     return this.__data[attr];
                 }
@@ -294,10 +296,12 @@ Schema.prototype.define = function defineClass(className, properties, settings) 
                 if (NewClass.setter[attr]) {
                     NewClass.setter[attr].call(this, value);
                 } else {
-                    if (value === null || value === undefined || typeof DataType === 'object' || DataType === Array) {
+                    if (value === null || value === undefined || typeof DataType === 'object') {
                         this.__data[attr] = value;
                     } else if (DataType === Boolean) {
                         this.__data[attr] = value === 'false' ? false : !!value;
+                    } else if (DataType === Array) {
+                        this.__data[attr].items = value;
                     } else {
                         this.__data[attr] = DataType(value);
                     }


### PR DESCRIPTION
Before the fix doing this:

```
var array = [1, 2, 3];
console.log(array);
myModelObject.array = array
console.log(myModelObject.array);
```

would print this:

```
[1, 2, 3]
[ [1, 2, 3] ]
```

After the fix the arrays are correctly assigned and the example above prints out:

```
[1, 2, 3]
[1, 2, 3]
```

Furthermore, storing such an array into the database was working correctly but retrieval of arrays was adding bogus "id" fields and converting values like strings from "123" into objects like { "123", id: 1 }. To make the matters worse this was applied to all the items in arrays.

I didn't find any better solution that to simply skip creating ListItem objects for Arrays. To be honest I suspect that there is a good reason to insert those "id"s but for me it was simply corrupting the data.

Finally, I changed the original commit to work, I think, more cleanly with arrays in lists, reading and setting them in list.items property.
