### PR TITLE
Fixed bad update of record in the memory on save()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -337,7 +337,7 @@ AbstractClass.upsert = AbstractClass.updateOrCreate = function upsert(data, call
 /**
  * Find one record, same as `all`, limited by 1 and return object, not collection,
  * if not found, create using data provided as second argument
- * 
+ *
  * @param {Object} query - search conditions: {where: {test: 'me'}}.
  * @param {Object} data - object to create.
  * @param {Function} cb - callback called with (err, instance)
@@ -534,7 +534,7 @@ AbstractClass.iterate = function map(filter, iterator, callback) {
 
 /**
  * Find one record, same as `all`, limited by 1 and return object, not collection
- * 
+ *
  * @param {Object} params - search conditions: {where: {test: 'me'}}
  * @param {Function} cb - callback called with (err, instance)
  */
@@ -622,7 +622,7 @@ AbstractClass.prototype.save = function (options, callback) {
 
     if (!this.id) {
         // Pass options and this to create
-        var data = { 
+        var data = {
             data: this,
             options: options
         };
@@ -651,11 +651,15 @@ AbstractClass.prototype.save = function (options, callback) {
     function save() {
         inst.trigger('save', function (saveDone) {
             inst.trigger('update', function (updateDone) {
-                inst._adapter().save(modelName, inst.constructor._forDB(data), function (err) {
+                //  Prepare the data for the db and then save it.
+                var dbData = inst.constructor._forDB(data);
+                inst._adapter().save(modelName, dbData, function (err) {
                     if (err) {
                         return callback(err, inst);
                     }
-                    inst._initProperties(data, false);
+                    //  Update the inst properties with the properties from the dbData
+                    //  as *that* object may have been changed by save() (e.g. revision number)
+                    inst._initProperties(dbData, false);
                     updateDone.call(inst, function () {
                         saveDone.call(inst, function () {
                             callback(err, inst);
@@ -683,7 +687,7 @@ AbstractClass.prototype._adapter = function () {
  * Convert instance to Object
  *
  * @param {Boolean} onlySchema - restrict properties to schema only, default false
- * when onlySchema == true, only properties defined in schema returned, 
+ * when onlySchema == true, only properties defined in schema returned,
  * otherwise all enumerable properties returned
  * @returns {Object} - canonical object representation (no getters and setters)
  */


### PR DESCRIPTION
The invocation of `inst._adapter().save` passes a data object that is immediately discarded so even if the adapter changes the data object during the saving (e.g. sets a new revision) it has no effect in `inst._initProperties(data, false);` as _that_ `data` object was never changed (nor could it be as adapter never had access to it).

I fixed this problem by keeping a reference to the adapted data object and then using that object to update `inst`.
