### PR TITLE
Fix empty callbacks with many includes

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -43,18 +43,22 @@ AbstractClass.include = function (objects, include, cb) {
     var objsByKeys = {};
 
     var nbCallbacks = 0;
+    var totalCallbacks = 0;
 
     for (var i = 0; i < include.length; i++) {
         var callback = processIncludeItem(this, objects, include[i], keyVals, objsByKeys);
         if (callback !== null) {
+            totalCallbacks++;
             if (callback instanceof Error) {
                 cb(callback);
             } else {
                 includeItemCallback(callback);
             }
-        } else {
-            cb(null, objects);
         }
+    }
+
+    if (totalCallbacks == 0) {
+        cb(null, objects);
     }
 
     function includeItemCallback(itemCb) {


### PR DESCRIPTION
In case of many includes, if the first is null the general callback is called but it shouldn't.

Callback was called potentially many times.
