### PR TITLE
[table-creation] delegate tableOptions to subclasses

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -171,6 +171,6 @@ BaseSQL.prototype.dropTable = function (model, cb) {
 
 BaseSQL.prototype.createTable = function (model, cb) {
     this.command('CREATE TABLE ' + this.tableEscaped(model) +
-        ' (\n  ' + this.propertiesSQL(model) + '\n)', cb);
+        this.propertiesSQL(model), cb);
 };
 


### PR DESCRIPTION
Allow to specify engine in mysql in jugglingdb/mysql-adapter#102.

It should break other sql adapters but it should be better that subclasses manage table options, etc... ?