### PR TITLE
Added callback parameter to disconnect()

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -138,8 +138,8 @@ BaseSQL.prototype.updateAttributes = function updateAttrs(model, id, data, cb) {
     this.save(model, data, cb);
 };
 
-BaseSQL.prototype.disconnect = function disconnect() {
-    this.client.end();
+BaseSQL.prototype.disconnect = function disconnect(cb) {
+    this.client.end(cb);
 };
 
 BaseSQL.prototype.automigrate = function (cb) {


### PR DESCRIPTION
The disconnect() function was missing a callback parameter, which its callee is providing and 'this.client.end' is expecting.